### PR TITLE
Queues

### DIFF
--- a/relayer_base/Cargo.toml
+++ b/relayer_base/Cargo.toml
@@ -49,3 +49,7 @@ mockito = { workspace = true }
 [[bin]]
 name = "price_feed"
 path = "src/bin/price_feed.rs"
+
+[[bin]]
+name = "queue_migration"
+path = "src/bin/scripts/queue_migration.rs"

--- a/relayer_base/src/bin/scripts/queue_migration.rs
+++ b/relayer_base/src/bin/scripts/queue_migration.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
 
     let args: Vec<String> = env::args().collect();
     if args.len() != 3 {
-        eprintln!("Usage: {} <src_queue> <dst_queue>", args[0]);
+        error!("Usage: {} <src_queue> <dst_queue>", args[0]);
         std::process::exit(1);
     }
     let src_queue = &args[1];

--- a/relayer_base/src/bin/scripts/queue_migration.rs
+++ b/relayer_base/src/bin/scripts/queue_migration.rs
@@ -6,9 +6,14 @@ use lapin::{
     types::FieldTable,
     BasicProperties, Channel, Connection, ConnectionProperties,
 };
-use relayer_base::{config::Config, utils::setup_logging};
+use relayer_base::{
+    config::Config,
+    gmp_api::gmp_types::TaskKind,
+    queue::{Queue, QueueItem},
+    utils::setup_logging,
+};
 use std::env;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -17,55 +22,52 @@ async fn main() -> Result<()> {
     let config = Config::from_yaml(&format!("config.{}.yaml", network))?;
     let _guard = setup_logging(&config);
 
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 3 {
-        error!("Usage: {} <src_queue> <dst_queue>", args[0]);
-        std::process::exit(1);
-    }
-    let src_queue = &args[1];
-    let dst_queue = &args[2];
-
-    let conn = Connection::connect(&config.queue_address, ConnectionProperties::default()).await?;
-    let channel: Channel = conn.create_channel().await?;
+    //let conn = Connection::connect(&config.queue_address, ConnectionProperties::default()).await?;
+    //let channel: Channel = conn.create_channel().await?;
     info!("Connected to {}", &config.queue_address);
 
-    let mut consumer = channel
-        .basic_consume(
-            src_queue,
-            "migrator",
-            BasicConsumeOptions::default(),
-            FieldTable::default(),
-        )
-        .await?;
-    info!("Moving messages: from '{}' to '{}'", src_queue, dst_queue);
+    let tasks_queue = Queue::new(&config.queue_address, "tasks").await;
+    let includer_tasks_queue = Queue::new(&config.queue_address, "includer_tasks").await;
+    let ingestor_tasks_queue = Queue::new(&config.queue_address, "ingestor_tasks").await;
+
+    let mut consumer = tasks_queue.consumer().await?;
+    info!(
+        "Moving messages: from 'tasks' queue to 'includer_tasks' and 'ingestor_tasks' accordingly"
+    );
 
     while let Some(maybe_delivery) = consumer.next().await {
         match maybe_delivery {
             Ok(delivery) => {
-                let payload = delivery.data.clone();
-
-                if let Err(e) = channel
-                    .basic_publish(
-                        "",
-                        dst_queue,
-                        BasicPublishOptions::default(),
-                        &payload,
-                        BasicProperties::default().with_delivery_mode(2), // persistent
-                    )
-                    .await
-                {
-                    error!("Publish to '{}' failed: {}", dst_queue, e);
-                    continue;
-                }
+                let data = delivery.data.clone();
+                let task_item: QueueItem = serde_json::from_slice::<QueueItem>(&data).unwrap();
+                let task = match task_item.clone() {
+                    QueueItem::Task(task) => task,
+                    _ => continue,
+                };
+                info!("Publishing task: {:?}", task);
+                let queue = match task.kind() {
+                    TaskKind::Refund | TaskKind::GatewayTx => includer_tasks_queue.clone(),
+                    TaskKind::Verify
+                    | TaskKind::ConstructProof
+                    | TaskKind::ReactToWasmEvent
+                    | TaskKind::ReactToRetriablePoll
+                    | TaskKind::ReactToExpiredSigningSession => ingestor_tasks_queue.clone(),
+                    TaskKind::Unknown | TaskKind::Execute => {
+                        warn!("Dropping and acking unknown task: {:?}", task);
+                        delivery.ack(BasicAckOptions::default()).await.unwrap();
+                        continue;
+                    }
+                };
+                queue.publish(task_item.clone()).await;
 
                 if let Err(e) = delivery.ack(BasicAckOptions::default()).await {
                     error!("ACK of source queue failed: {}", e);
                 } else {
-                    info!("Moved one message");
+                    info!("Moved one entry to the appropriate queue");
                 }
             }
             Err(e) => {
-                error!("Error reading from '{}': {:?}", src_queue, e);
+                error!("Error reading from 'tasks_queue': {:?}", e);
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
         }

--- a/relayer_base/src/bin/scripts/queue_migration.rs
+++ b/relayer_base/src/bin/scripts/queue_migration.rs
@@ -1,0 +1,92 @@
+use anyhow::Result;
+use futures::StreamExt;
+use lapin::{
+    options::{
+        BasicAckOptions, BasicConsumeOptions, BasicNackOptions, BasicPublishOptions,
+        QueueDeclareOptions,
+    },
+    types::FieldTable,
+    BasicProperties, Channel, Connection, ConnectionProperties,
+};
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 4 {
+        eprintln!("Usage: {} <amqp_url> <src_queue> <dst_queue>", args[0]);
+        std::process::exit(1);
+    }
+    let queue_url = &args[1];
+    let src_queue = &args[2];
+    let dst_queue = &args[3];
+
+    let conn = Connection::connect(queue_url, ConnectionProperties::default()).await?;
+    let channel: Channel = conn.create_channel().await?;
+    info!("connected to {}", queue_url);
+
+    channel
+        .queue_declare(
+            dst_queue,
+            QueueDeclareOptions {
+                durable: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await?;
+    info!("destination queue: {}", dst_queue);
+
+    let mut consumer = channel
+        .basic_consume(
+            src_queue,
+            "migrator",
+            BasicConsumeOptions::default(),
+            FieldTable::default(),
+        )
+        .await?;
+    info!("consuming from source queue: {}", src_queue);
+
+    while let Some(delivery_result) = consumer.next().await {
+        match delivery_result {
+            Ok(delivery) => {
+                let payload = delivery.data.clone();
+
+                let maybe_publish = channel
+                    .basic_publish(
+                        "",
+                        dst_queue,
+                        BasicPublishOptions::default(),
+                        &payload,
+                        BasicProperties::default().with_delivery_mode(2),
+                    )
+                    .await;
+
+                match maybe_publish {
+                    Ok(confirm) => {
+                        let _ = confirm.await;
+                        delivery.ack(BasicAckOptions::default()).await?;
+                        info!("moved one message from {} to {}", src_queue, dst_queue);
+                    }
+                    Err(e) => {
+                        error!("failed to publish to {}: {}", dst_queue, e);
+                        delivery
+                            .nack(BasicNackOptions {
+                                multiple: false,
+                                requeue: true,
+                            })
+                            .await?;
+                    }
+                }
+            }
+            Err(e) => {
+                error!("consumer error on {}: {:?}", src_queue, e);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/relayer_base/src/bin/scripts/queue_migration.rs
+++ b/relayer_base/src/bin/scripts/queue_migration.rs
@@ -2,10 +2,7 @@ use anyhow::Result;
 use dotenv::dotenv;
 use futures::StreamExt;
 use lapin::{
-    options::{
-        BasicAckOptions, BasicConsumeOptions, BasicNackOptions, BasicPublishOptions,
-        QueueDeclareOptions,
-    },
+    options::{BasicAckOptions, BasicConsumeOptions, BasicPublishOptions},
     types::FieldTable,
     BasicProperties, Channel, Connection, ConnectionProperties,
 };
@@ -16,35 +13,21 @@ use tracing::{error, info};
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv().ok();
-    let network = std::env::var("NETWORK").expect("NETWORK must be set");
+    let network = env::var("NETWORK").expect("NETWORK must be set");
     let config = Config::from_yaml(&format!("config.{}.yaml", network))?;
-
     let _guard = setup_logging(&config);
 
     let args: Vec<String> = env::args().collect();
     if args.len() != 3 {
-        error!("Usage: {} <src_queue> <dst_queue>", args[0]);
+        eprintln!("Usage: {} <src_queue> <dst_queue>", args[0]);
         std::process::exit(1);
     }
-
     let src_queue = &args[1];
     let dst_queue = &args[2];
 
     let conn = Connection::connect(&config.queue_address, ConnectionProperties::default()).await?;
     let channel: Channel = conn.create_channel().await?;
-    info!("connected to {}", &config.queue_address);
-
-    channel
-        .queue_declare(
-            dst_queue,
-            QueueDeclareOptions {
-                durable: true,
-                ..Default::default()
-            },
-            FieldTable::default(),
-        )
-        .await?;
-    info!("destination queue: {}", dst_queue);
+    info!("Connected to {}", &config.queue_address);
 
     let mut consumer = channel
         .basic_consume(
@@ -54,42 +37,36 @@ async fn main() -> Result<()> {
             FieldTable::default(),
         )
         .await?;
-    info!("consuming from source queue: {}", src_queue);
+    info!("Moving messages: from '{}' to '{}'", src_queue, dst_queue);
 
     while let Some(delivery_result) = consumer.next().await {
         match delivery_result {
             Ok(delivery) => {
                 let payload = delivery.data.clone();
 
-                let maybe_publish = channel
+                if let Err(e) = channel
                     .basic_publish(
                         "",
                         dst_queue,
                         BasicPublishOptions::default(),
                         &payload,
-                        BasicProperties::default().with_delivery_mode(2),
+                        BasicProperties::default().with_delivery_mode(2), // persistent
                     )
-                    .await;
+                    .await
+                {
+                    error!("Publish to '{}' failed: {}", dst_queue, e);
+                    continue;
+                }
 
-                match maybe_publish {
-                    Ok(confirm) => {
-                        let _ = confirm.await;
-                        delivery.ack(BasicAckOptions::default()).await?;
-                        info!("moved one message from {} to {}", src_queue, dst_queue);
-                    }
-                    Err(e) => {
-                        error!("failed to publish to {}: {}", dst_queue, e);
-                        delivery
-                            .nack(BasicNackOptions {
-                                multiple: false,
-                                requeue: true,
-                            })
-                            .await?;
-                    }
+                if let Err(e) = delivery.ack(BasicAckOptions::default()).await {
+                    error!("ACK of source queue failed: {}", e);
+                } else {
+                    info!("Moved one message");
                 }
             }
             Err(e) => {
-                error!("consumer error on {}: {:?}", src_queue, e);
+                error!("Error reading from '{}': {:?}", src_queue, e);
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
         }
     }

--- a/relayer_base/src/bin/scripts/queue_migration.rs
+++ b/relayer_base/src/bin/scripts/queue_migration.rs
@@ -39,8 +39,8 @@ async fn main() -> Result<()> {
         .await?;
     info!("Moving messages: from '{}' to '{}'", src_queue, dst_queue);
 
-    while let Some(delivery_result) = consumer.next().await {
-        match delivery_result {
+    while let Some(maybe_delivery) = consumer.next().await {
+        match maybe_delivery {
             Ok(delivery) => {
                 let payload = delivery.data.clone();
 

--- a/relayer_base/src/distributor.rs
+++ b/relayer_base/src/distributor.rs
@@ -126,7 +126,7 @@ impl<DB: Database> Distributor<DB> {
                 | TaskKind::ReactToWasmEvent
                 | TaskKind::ReactToRetriablePoll
                 | TaskKind::ReactToExpiredSigningSession => ingestor_queue.clone(),
-                _ => {
+                TaskKind::Unknown | TaskKind::Execute => {
                     warn!("Dropping unknown task: {:?}", task);
                     continue;
                 }

--- a/relayer_base/src/distributor.rs
+++ b/relayer_base/src/distributor.rs
@@ -108,11 +108,6 @@ impl<DB: Database> Distributor<DB> {
                 }
             }
 
-            if task.kind() == TaskKind::Unknown {
-                warn!("Dropping unknown task: {:?}", task);
-                continue;
-            }
-
             if task.kind() == TaskKind::Refund && !self.refunds_enabled {
                 continue;
             }

--- a/xrpl/src/bin/recovery/xrpl_task_recovery.rs
+++ b/xrpl/src/bin/recovery/xrpl_task_recovery.rs
@@ -19,7 +19,8 @@ async fn main() -> anyhow::Result<()> {
 
     let _guard = setup_logging(&config);
 
-    let tasks_queue = Queue::new(&config.queue_address, "tasks").await;
+    let includer_tasks_queue = Queue::new(&config.queue_address, "includer_tasks").await;
+    let ingestor_tasks_queue = Queue::new(&config.queue_address, "ingestor_tasks").await;
     let gmp_api = Arc::new(gmp_api::GmpApi::new(&config, true).unwrap());
     let postgres_db = PostgresDB::new(&config.postgres_url).await.unwrap();
 
@@ -45,10 +46,14 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         _ = sigint.recv()  => {},
         _ = sigterm.recv() => {},
-        _ = distributor.run_recovery(tasks_queue.clone()) => {},
+        _ = distributor.run_recovery(
+            includer_tasks_queue.clone(),
+            ingestor_tasks_queue.clone(),
+        ) => {},
     }
 
-    tasks_queue.close().await;
+    includer_tasks_queue.close().await;
+    ingestor_tasks_queue.close().await;
 
     Ok(())
 }

--- a/xrpl/src/bin/xrpl_includer.rs
+++ b/xrpl/src/bin/xrpl_includer.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
 
     let _guard = setup_logging(&config);
 
-    let tasks_queue = Queue::new(&config.queue_address, "tasks").await;
+    let tasks_queue = Queue::new(&config.queue_address, "includer_tasks").await;
     let construct_proof_queue = Queue::new(&config.queue_address, "construct_proof").await;
     let gmp_api = Arc::new(gmp_api::GmpApi::new(&config, true).unwrap());
     let redis_client = redis::Client::open(config.redis_server.clone()).unwrap();

--- a/xrpl/src/bin/xrpl_ingestor.rs
+++ b/xrpl/src/bin/xrpl_ingestor.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
 
     let _guard = setup_logging(&config);
 
-    let tasks_queue = Queue::new(&config.queue_address, "tasks").await;
+    let tasks_queue = Queue::new(&config.queue_address, "ingestor_tasks").await;
     let events_queue = Queue::new(&config.queue_address, "events").await;
     let gmp_api = Arc::new(gmp_api::GmpApi::new(&config, true).unwrap());
     let postgres_db = PostgresDB::new(&config.postgres_url).await.unwrap();


### PR DESCRIPTION
Seperated queues for includer and ingestor tasks to avoid unnecessary task errors.
Use the queue_migration script to move the tasks from the old 'tasks' queue to the two new 'includer_tasks' and 'ingestor_tasks' queue.

**Deployment Steps:**

1. Deploy Distributor: it will start populating the new queues.
2. Deploy Includer
3. Deploy Ingestor
4. There might be leftover tasks in the old `tasks` queue. Run the migration script to transfer those tasks to the new queue: `cargo run --bin queue_migration`