### PR TITLE
Ter queued

### DIFF
--- a/migrations/0009_xrpl_queued_transactions
+++ b/migrations/0009_xrpl_queued_transactions
@@ -1,0 +1,11 @@
+CREATE TYPE xrpl_queued_transaction_status as ENUM ('queued', 'confirmed', 'dropped', 'expired');
+
+CREATE TABLE IF NOT EXISTS xrpl_queued_transactions (
+    tx_hash TEXT PRIMARY KEY,
+    account TEXT NOT NULL,
+    sequence BIGINT NOT NULL,
+    status xrpl_queued_transaction_status NOT NULL,
+    retries INTEGER DEFAULT 0,
+    submitted TIMESTAMP DEFAULT now() NOT NULL,
+    last_checked TIMESTAMP DEFAULT now(),
+);

--- a/migrations/0009_xrpl_queued_transactions.sql
+++ b/migrations/0009_xrpl_queued_transactions.sql
@@ -7,5 +7,5 @@ CREATE TABLE IF NOT EXISTS xrpl_queued_transactions (
     status xrpl_queued_transaction_status NOT NULL,
     retries INTEGER DEFAULT 0,
     submitted TIMESTAMP DEFAULT now() NOT NULL,
-    last_checked TIMESTAMP DEFAULT now(),
+    last_checked TIMESTAMP DEFAULT now()
 );

--- a/relayer_base/src/database.rs
+++ b/relayer_base/src/database.rs
@@ -197,19 +197,19 @@ impl Database for PostgresDB {
     }
 
     async fn mark_queued_transaction_confirmed(&self, tx_hash: &str) -> Result<()> {
-        let query = "UPDATE xrpl_queued_transactions SET status = 'confirmed' WHERE tx_hash = $1";
+        let query = "UPDATE xrpl_queued_transactions SET status = 'confirmed', last_checked = now() WHERE tx_hash = $1";
         sqlx::query(query).bind(tx_hash).execute(&self.pool).await?;
         Ok(())
     }
 
     async fn mark_queued_transaction_dropped(&self, tx_hash: &str) -> Result<()> {
-        let query = "UPDATE xrpl_queued_transactions SET status = 'dropped' WHERE tx_hash = $1";
+        let query = "UPDATE xrpl_queued_transactions SET status = 'dropped', last_checked = now() WHERE tx_hash = $1";
         sqlx::query(query).bind(tx_hash).execute(&self.pool).await?;
         Ok(())
     }
 
     async fn mark_queued_transaction_expired(&self, tx_hash: &str) -> Result<()> {
-        let query = "UPDATE xrpl_queued_transactions SET status = 'expired' WHERE tx_hash = $1";
+        let query = "UPDATE xrpl_queued_transactions SET status = 'expired', last_checked = now() WHERE tx_hash = $1";
         sqlx::query(query).bind(tx_hash).execute(&self.pool).await?;
         Ok(())
     }

--- a/relayer_base/src/error.rs
+++ b/relayer_base/src/error.rs
@@ -101,3 +101,15 @@ pub enum SubscriberError {
     #[error("Generic error: {0}")]
     GenericError(String),
 }
+
+#[derive(Error, Debug)]
+pub enum QueuedTxMonitorError {
+    #[error("Database error: {0}")]
+    DatabaseError(String),
+    #[error("XRPL client error: {0}")]
+    XRPLClientError(String),
+    #[error("Transaction status check failed: {0}")]
+    TransactionStatusCheckFailed(String),
+    #[error("Generic error: {0}")]
+    GenericError(String),
+}

--- a/relayer_base/src/includer.rs
+++ b/relayer_base/src/includer.rs
@@ -145,6 +145,7 @@ where
                         "Broadcasting transaction with hash: {:?}",
                         broadcast_result.tx_hash
                     );
+
                     if broadcast_result.message_id.is_some()
                         && broadcast_result.source_chain.is_some()
                     {

--- a/xrpl/Cargo.toml
+++ b/xrpl/Cargo.toml
@@ -75,3 +75,7 @@ path = "src/bin/recovery/xrpl_task_recovery.rs"
 [[bin]]
 name = "xrpl_heartbeat_monitor"
 path = "src/bin/xrpl_heartbeat_monitor.rs"
+
+[[bin]]
+name = "xrpl_queued_tx_monitor"
+path = "src/bin/xrpl_queued_tx_monitor.rs"

--- a/xrpl/src/bin/xrpl_includer.rs
+++ b/xrpl/src/bin/xrpl_includer.rs
@@ -27,13 +27,14 @@ async fn main() -> anyhow::Result<()> {
     let redis_client = redis::Client::open(config.redis_server.clone()).unwrap();
     let redis_pool = r2d2::Pool::builder().build(redis_client).unwrap();
     let postgres_db = PostgresDB::new(&config.postgres_url).await.unwrap();
-    let payload_cache = PayloadCache::new(postgres_db);
+    let payload_cache = PayloadCache::new(postgres_db.clone());
     let xrpl_includer = XrplIncluder::new(
         config.clone(),
         gmp_api,
         redis_pool.clone(),
         payload_cache,
         construct_proof_queue.clone(),
+        postgres_db.clone(),
     )
     .await
     .unwrap();

--- a/xrpl/src/bin/xrpl_queued_tx_monitor.rs
+++ b/xrpl/src/bin/xrpl_queued_tx_monitor.rs
@@ -1,0 +1,39 @@
+use dotenv::dotenv;
+use std::sync::Arc;
+use tokio::signal::unix::{signal, SignalKind};
+
+use relayer_base::{
+    config::Config,
+    database::PostgresDB,
+    utils::{setup_heartbeat, setup_logging},
+};
+use xrpl::{client::XRPLClient, queued_tx_monitor::XrplQueuedTxMonitor};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenv().ok();
+    let network = std::env::var("NETWORK").expect("NETWORK must be set");
+    let config = Config::from_yaml(&format!("config.{}.yaml", network))?;
+
+    let _guard = setup_logging(&config);
+
+    let postgres_db = PostgresDB::new(&config.postgres_url).await?;
+    let xrpl_client = Arc::new(XRPLClient::new(&config.xrpl_rpc, 3)?);
+
+    let xrpl_tx_monitor = XrplQueuedTxMonitor::new(xrpl_client, postgres_db);
+
+    let redis_client = redis::Client::open(config.redis_server.clone())?;
+    let redis_pool = r2d2::Pool::builder().build(redis_client)?;
+    setup_heartbeat("heartbeat:queued_tx_monitor".to_owned(), redis_pool);
+
+    let mut sigint = signal(SignalKind::interrupt())?;
+    let mut sigterm = signal(SignalKind::terminate())?;
+
+    tokio::select! {
+        _ = sigint.recv() => {},
+        _ = sigterm.recv() => {},
+        _ = xrpl_tx_monitor.run() => {},
+    }
+
+    Ok(())
+}

--- a/xrpl/src/includer.rs
+++ b/xrpl/src/includer.rs
@@ -20,8 +20,9 @@ impl XrplIncluder {
         redis_pool: r2d2::Pool<redis::Client>,
         payload_cache: PayloadCache<DB>,
         construct_proof_queue: Arc<Queue>,
+        db: DB,
     ) -> error_stack::Result<
-        Includer<XRPLBroadcaster, Arc<XRPLClient>, XRPLRefundManager, DB>,
+        Includer<XRPLBroadcaster<DB>, Arc<XRPLClient>, XRPLRefundManager, DB>,
         BroadcasterError,
     > {
         let client =
@@ -29,7 +30,7 @@ impl XrplIncluder {
                 error_stack::report!(BroadcasterError::GenericError(e.to_string()))
             })?);
 
-        let broadcaster = XRPLBroadcaster::new(Arc::clone(&client))
+        let broadcaster = XRPLBroadcaster::new(Arc::clone(&client), db)
             .map_err(|e| e.attach_printable("Failed to create XRPLBroadcaster"))?;
 
         let refund_manager =

--- a/xrpl/src/lib.rs
+++ b/xrpl/src/lib.rs
@@ -4,6 +4,7 @@ pub mod funder;
 pub mod includer;
 pub mod ingestor;
 pub mod models;
+pub mod queued_tx_monitor;
 pub mod refund_manager;
 pub mod subscriber;
 pub mod ticket_creator;

--- a/xrpl/src/queued_tx_monitor.rs
+++ b/xrpl/src/queued_tx_monitor.rs
@@ -1,0 +1,130 @@
+use super::client::XRPLClient;
+use relayer_base::{database::Database, error::QueuedTxMonitorError};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, error, info, warn};
+use xrpl_api::TxRequest;
+use xrpl_http_client;
+
+const MAX_RETRIES: i32 = 20;
+pub struct XrplQueuedTxMonitor<DB: Database> {
+    client: Arc<XRPLClient>,
+    db: DB,
+}
+
+impl<DB: Database> XrplQueuedTxMonitor<DB> {
+    pub fn new(client: Arc<XRPLClient>, db: DB) -> Self {
+        Self { client, db }
+    }
+
+    async fn work(&self) {
+        if let Err(e) = self.check_queued_transactions().await {
+            error!("Error checking queued transactions: {}", e);
+        }
+    }
+
+    pub async fn run(&self) {
+        loop {
+            info!("XrplQueuedTxMonitor is alive.");
+            self.work().await;
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        }
+    }
+
+    async fn check_queued_transactions(&self) -> Result<(), QueuedTxMonitorError> {
+        let queued_txs = self
+            .db
+            .get_queued_transactions_ready_for_check()
+            .await
+            .map_err(|e| QueuedTxMonitorError::DatabaseError(e.to_string()))?;
+
+        debug!("Found {} queued transactions to check", queued_txs.len());
+
+        for tx in queued_txs {
+            if tx.retries >= MAX_RETRIES {
+                warn!(
+                    "Transaction {} exceeded max retries, marking as expired",
+                    tx.tx_hash
+                );
+                self.db
+                    .mark_queued_transaction_expired(&tx.tx_hash)
+                    .await
+                    .map_err(|e| QueuedTxMonitorError::DatabaseError(e.to_string()))?;
+                continue;
+            }
+
+            match self.check_transaction_status(&tx.tx_hash).await {
+                Ok(TxStatus::Confirmed) => {
+                    info!("Transaction {} confirmed", tx.tx_hash);
+                    self.db
+                        .mark_queued_transaction_confirmed(&tx.tx_hash)
+                        .await
+                        .map_err(|e| QueuedTxMonitorError::DatabaseError(e.to_string()))?;
+                }
+                Ok(TxStatus::Queued) => {
+                    info!(
+                        "Transaction {} still queued, incrementing retry count to {}",
+                        tx.tx_hash,
+                        tx.retries + 1
+                    );
+                    self.db
+                        .increment_queued_transaction_retry(&tx.tx_hash)
+                        .await
+                        .map_err(|e| QueuedTxMonitorError::DatabaseError(e.to_string()))?;
+                }
+                Ok(TxStatus::Dropped) => {
+                    warn!("Transaction {} dropped", tx.tx_hash);
+                    self.db
+                        .mark_queued_transaction_dropped(&tx.tx_hash)
+                        .await
+                        .map_err(|e| QueuedTxMonitorError::DatabaseError(e.to_string()))?;
+                }
+                Err(e) => {
+                    error!("Error checking transaction {}: {}", tx.tx_hash, e);
+                    self.db
+                        .increment_queued_transaction_retry(&tx.tx_hash)
+                        .await
+                        .map_err(|e| QueuedTxMonitorError::DatabaseError(e.to_string()))?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn check_transaction_status(
+        &self,
+        tx_hash: &str,
+    ) -> Result<TxStatus, QueuedTxMonitorError> {
+        let req = TxRequest::new(tx_hash);
+
+        match self.client.call(req).await {
+            Ok(query_response) => {
+                if query_response.tx.common().validated == Some(true) {
+                    debug!("Transaction {} confirmed", tx_hash);
+                    Ok(TxStatus::Confirmed)
+                } else {
+                    debug!("Transaction {} queued", tx_hash);
+                    Ok(TxStatus::Queued)
+                }
+            }
+            Err(e) => match e {
+                xrpl_http_client::error::Error::Api(error_code) if error_code == "txnNotFound" => {
+                    debug!("Transaction {} not found, marking as dropped", tx_hash);
+                    Ok(TxStatus::Dropped)
+                }
+                _ => {
+                    // TODO: How to handle this?
+                    debug!("Error checking transaction {}: {}", tx_hash, e);
+                    Err(QueuedTxMonitorError::XRPLClientError(e.to_string()))
+                }
+            },
+        }
+    }
+}
+
+pub enum TxStatus {
+    Confirmed,
+    Queued,
+    Dropped,
+}


### PR DESCRIPTION
Added monitor serice for queued XRPL transactions (transactions for which the RPC call returns terQueued).

Deployment Steps:

Run sqlx migrate run --database-url $DATABASE_URL to populate the PostgreSQL with the new table.
To launch the monitor run
cargo run --bin xrpl_queued_tx_monitor