### PR TITLE
improvement: Separate configuration per-chain

### DIFF
--- a/config/config.template.yaml
+++ b/config/config.template.yaml
@@ -8,9 +8,9 @@ xrpl_rpc: ""
 xrpl_multisig: ""
 xrpl_faucet_url: ""
 axelar_contracts:
-  xrpl_gateway: ""
-  xrpl_multisig_prover: ""
-  xrpl_voting_verifier: ""
+  chain_gateway: ""
+  chain_multisig_prover: ""
+  chain_voting_verifier: ""
   multisig: ""
 deployed_tokens: {}
 xrpl_relayer_sentry_dsn: ""

--- a/recovery_tools/src/bin/proof_retrier.rs
+++ b/recovery_tools/src/bin/proof_retrier.rs
@@ -2,19 +2,19 @@ use dotenv::dotenv;
 use tokio::signal::unix::{signal, SignalKind};
 
 use relayer_base::{
-    config::Config,
     database::PostgresDB,
     payload_cache::PayloadCache,
     proof_retrier::ProofRetrier,
     queue::Queue,
     utils::{setup_heartbeat, setup_logging},
 };
+use relayer_base::config::{config_from_yaml, Config};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: Config = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
 
     let _guard = setup_logging(&config);
 

--- a/relayer_base/src/bin/price_feed.rs
+++ b/relayer_base/src/bin/price_feed.rs
@@ -1,16 +1,16 @@
 use dotenv::dotenv;
 use relayer_base::{
-    config::Config,
     database::PostgresDB,
     price_feed::PriceFeeder,
     utils::{setup_heartbeat, setup_logging},
 };
+use relayer_base::config::config_from_yaml;
 
 #[tokio::main]
 async fn main() {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
 
     let _guard = setup_logging(&config);
 

--- a/relayer_base/src/bin/scripts/queue_migration.rs
+++ b/relayer_base/src/bin/scripts/queue_migration.rs
@@ -7,19 +7,19 @@ use lapin::{
     BasicProperties, Channel, Connection, ConnectionProperties,
 };
 use relayer_base::{
-    config::Config,
     gmp_api::gmp_types::TaskKind,
     queue::{Queue, QueueItem},
     utils::setup_logging,
 };
 use std::env;
 use tracing::{error, info, warn};
+use relayer_base::config::config_from_yaml;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv().ok();
     let network = env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network))?;
+    let config = config_from_yaml(&format!("config.{}.yaml", network))?;
     let _guard = setup_logging(&config);
 
     //let conn = Connection::connect(&config.queue_address, ConnectionProperties::default()).await?;

--- a/xrpl/src/bin/xrpl_distributor.rs
+++ b/xrpl/src/bin/xrpl_distributor.rs
@@ -3,39 +3,40 @@ use std::sync::Arc;
 use tokio::signal::unix::{signal, SignalKind};
 
 use relayer_base::{
-    config::Config,
     database::PostgresDB,
     distributor::Distributor,
     gmp_api,
     queue::Queue,
     utils::{setup_heartbeat, setup_logging},
 };
+use relayer_base::config::{config_from_yaml};
+use xrpl::config::XRPLConfig;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
 
-    let _guard = setup_logging(&config);
+    let _guard = setup_logging(&config.common_config);
 
-    let includer_tasks_queue = Queue::new(&config.queue_address, "includer_tasks").await;
-    let ingestor_tasks_queue = Queue::new(&config.queue_address, "ingestor_tasks").await;
-    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config, true).unwrap());
-    let postgres_db = PostgresDB::new(&config.postgres_url).await.unwrap();
+    let includer_tasks_queue = Queue::new(&config.common_config.queue_address, "includer_tasks").await;
+    let ingestor_tasks_queue = Queue::new(&config.common_config.queue_address, "ingestor_tasks").await;
+    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, true).unwrap());
+    let postgres_db = PostgresDB::new(&config.common_config.postgres_url).await.unwrap();
 
     let mut distributor = Distributor::new(
         postgres_db,
         "default".to_string(),
         gmp_api,
-        config.refunds_enabled,
+        config.common_config.refunds_enabled,
     )
     .await;
 
     let mut sigint = signal(SignalKind::interrupt())?;
     let mut sigterm = signal(SignalKind::terminate())?;
 
-    let redis_client = redis::Client::open(config.redis_server.clone()).unwrap();
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone()).unwrap();
     let redis_pool = r2d2::Pool::builder().build(redis_client).unwrap();
 
     setup_heartbeat("heartbeat:distributor".to_owned(), redis_pool);

--- a/xrpl/src/bin/xrpl_funder.rs
+++ b/xrpl/src/bin/xrpl_funder.rs
@@ -3,19 +3,20 @@ use dotenv::dotenv;
 use xrpl::funder::XRPLFunder;
 
 use relayer_base::{
-    config::Config,
     utils::{setup_heartbeat, setup_logging},
 };
+use relayer_base::config::{config_from_yaml};
+use xrpl::config::XRPLConfig;
 
 #[tokio::main]
 async fn main() {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
 
-    let _guard = setup_logging(&config);
+    let _guard = setup_logging(&config.common_config);
 
-    let redis_client = redis::Client::open(config.redis_server.clone()).unwrap();
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone()).unwrap();
     let redis_pool = r2d2::Pool::builder().build(redis_client).unwrap();
 
     setup_heartbeat("heartbeat:funder".to_owned(), redis_pool);

--- a/xrpl/src/bin/xrpl_heartbeat_monitor.rs
+++ b/xrpl/src/bin/xrpl_heartbeat_monitor.rs
@@ -1,26 +1,28 @@
 use dotenv::dotenv;
 
 use redis::Commands;
-use relayer_base::{config::Config, utils::setup_logging};
+use relayer_base::{utils::setup_logging};
 use tracing::{debug, error};
+use relayer_base::config::{config_from_yaml};
+use xrpl::config::XRPLConfig;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network))?;
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network))?;
 
-    let redis_client = redis::Client::open(config.redis_server.clone())?;
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone())?;
     let redis_pool = r2d2::Pool::builder().build(redis_client)?;
 
     let client = reqwest::Client::new();
 
-    let _guard = setup_logging(&config);
+    let _guard = setup_logging(&config.common_config);
 
     loop {
         debug!("Sending heartbeats to sentry monitoring endpoint");
 
-        for (key, url) in config.heartbeats.iter() {
+        for (key, url) in config.common_config.heartbeats.iter() {
             let redis_key = format!("heartbeat:{}", key);
             let mut redis_conn = redis_pool.get().unwrap();
             if redis_conn.get(redis_key).unwrap_or(0) == 1 {

--- a/xrpl/src/bin/xrpl_includer.rs
+++ b/xrpl/src/bin/xrpl_includer.rs
@@ -3,30 +3,30 @@ use std::sync::Arc;
 use tokio::signal::unix::{signal, SignalKind};
 
 use relayer_base::{
-    config::Config,
     database::PostgresDB,
     gmp_api,
     payload_cache::PayloadCache,
     queue::Queue,
     utils::{setup_heartbeat, setup_logging},
 };
-
+use relayer_base::config::{config_from_yaml};
+use xrpl::config::XRPLConfig;
 use xrpl::includer::XrplIncluder;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
 
-    let _guard = setup_logging(&config);
+    let _guard = setup_logging(&config.common_config);
 
-    let tasks_queue = Queue::new(&config.queue_address, "includer_tasks").await;
-    let construct_proof_queue = Queue::new(&config.queue_address, "construct_proof").await;
-    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config, true).unwrap());
-    let redis_client = redis::Client::open(config.redis_server.clone()).unwrap();
+    let tasks_queue = Queue::new(&config.common_config.queue_address, "includer_tasks").await;
+    let construct_proof_queue = Queue::new(&config.common_config.queue_address, "construct_proof").await;
+    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, true).unwrap());
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone()).unwrap();
     let redis_pool = r2d2::Pool::builder().build(redis_client).unwrap();
-    let postgres_db = PostgresDB::new(&config.postgres_url).await.unwrap();
+    let postgres_db = PostgresDB::new(&config.common_config.postgres_url).await.unwrap();
     let payload_cache = PayloadCache::new(postgres_db);
     let xrpl_includer = XrplIncluder::new(
         config.clone(),

--- a/xrpl/src/bin/xrpl_ingestor.rs
+++ b/xrpl/src/bin/xrpl_ingestor.rs
@@ -9,7 +9,6 @@ use xrpl::{
 };
 
 use relayer_base::{
-    config::Config,
     database::PostgresDB,
     gmp_api,
     ingestor::Ingestor,
@@ -19,20 +18,22 @@ use relayer_base::{
     queue::Queue,
     utils::{setup_heartbeat, setup_logging},
 };
+use relayer_base::config::{config_from_yaml};
+use xrpl::config::XRPLConfig;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
 
-    let _guard = setup_logging(&config);
+    let _guard = setup_logging(&config.common_config);
 
-    let tasks_queue = Queue::new(&config.queue_address, "ingestor_tasks").await;
-    let events_queue = Queue::new(&config.queue_address, "events").await;
-    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config, true).unwrap());
-    let postgres_db = PostgresDB::new(&config.postgres_url).await.unwrap();
-    let pg_pool = PgPool::connect(&config.postgres_url).await.unwrap();
+    let tasks_queue = Queue::new(&config.common_config.queue_address, "ingestor_tasks").await;
+    let events_queue = Queue::new(&config.common_config.queue_address, "events").await;
+    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, true).unwrap());
+    let postgres_db = PostgresDB::new(&config.common_config.postgres_url).await.unwrap();
+    let pg_pool = PgPool::connect(&config.common_config.postgres_url).await.unwrap();
     let price_view = PriceView::new(postgres_db.clone());
     let payload_cache = PayloadCache::new(postgres_db.clone());
     let models = XrplIngestorModels {
@@ -56,7 +57,7 @@ async fn main() -> anyhow::Result<()> {
     let mut sigint = signal(SignalKind::interrupt())?;
     let mut sigterm = signal(SignalKind::terminate())?;
 
-    let redis_client = redis::Client::open(config.redis_server.clone())?;
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone())?;
     let redis_pool = r2d2::Pool::builder().build(redis_client)?;
 
     setup_heartbeat("heartbeat:ingestor".to_owned(), redis_pool);

--- a/xrpl/src/bin/xrpl_subscriber.rs
+++ b/xrpl/src/bin/xrpl_subscriber.rs
@@ -1,7 +1,6 @@
 use dotenv::dotenv;
 
 use relayer_base::{
-    config::Config,
     database::PostgresDB,
     queue::Queue,
     subscriber::Subscriber,
@@ -9,19 +8,20 @@ use relayer_base::{
 };
 use tokio::signal::unix::{signal, SignalKind};
 use xrpl_types::AccountId;
-
+use relayer_base::config::{config_from_yaml};
+use xrpl::config::XRPLConfig;
 use xrpl::subscriber::XrplSubscriber;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
 
-    let _guard = setup_logging(&config);
+    let _guard = setup_logging(&config.common_config);
 
-    let events_queue = Queue::new(&config.queue_address, "events").await;
-    let postgres_db = PostgresDB::new(&config.postgres_url).await.unwrap();
+    let events_queue = Queue::new(&config.common_config.queue_address, "events").await;
+    let postgres_db = PostgresDB::new(&config.common_config.postgres_url).await.unwrap();
 
     let account = AccountId::from_address(&config.xrpl_multisig).unwrap();
 
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
     let mut sigint = signal(SignalKind::interrupt())?;
     let mut sigterm = signal(SignalKind::terminate())?;
 
-    let redis_client = redis::Client::open(config.redis_server.clone())?;
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone())?;
     let redis_pool = r2d2::Pool::builder().build(redis_client)?;
 
     setup_heartbeat("heartbeat:subscriber".to_owned(), redis_pool);

--- a/xrpl/src/bin/xrpl_ticket_creator.rs
+++ b/xrpl/src/bin/xrpl_ticket_creator.rs
@@ -2,27 +2,27 @@ use dotenv::dotenv;
 use std::sync::Arc;
 
 use relayer_base::{
-    config::Config,
     gmp_api,
     utils::{setup_heartbeat, setup_logging},
 };
-
+use relayer_base::config::{config_from_yaml};
+use xrpl::config::XRPLConfig;
 use xrpl::ticket_creator::XrplTicketCreator;
 
 #[tokio::main]
 async fn main() {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    
+    let _guard = setup_logging(&config.common_config);
 
-    let _guard = setup_logging(&config);
-
-    let redis_client = redis::Client::open(config.redis_server.clone()).unwrap();
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone()).unwrap();
     let redis_pool = r2d2::Pool::builder().build(redis_client).unwrap();
 
     setup_heartbeat("heartbeat:ticket_creator".to_owned(), redis_pool);
 
-    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config, false).unwrap());
+    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, false).unwrap());
     let ticket_creator = XrplTicketCreator::new(gmp_api.clone(), config.clone());
     ticket_creator.run().await;
 }

--- a/xrpl/src/bin/xrpl_ticket_monitor.rs
+++ b/xrpl/src/bin/xrpl_ticket_monitor.rs
@@ -1,13 +1,14 @@
 use dotenv::dotenv;
 
 use relayer_base::{
-    config::Config,
     utils::{setup_heartbeat, setup_logging},
 };
 use tracing::{debug, error};
 use xrpl::client::XRPLClient;
 use xrpl_api::Ticket;
 use xrpl_types::AccountId;
+use relayer_base::config::{config_from_yaml};
+use xrpl::config::XRPLConfig;
 
 const RETRIES: u8 = 4;
 const THRESHOLD: u8 = 150;
@@ -16,14 +17,14 @@ const THRESHOLD: u8 = 150;
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config = Config::from_yaml(&format!("config.{}.yaml", network))?;
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network))?;
 
-    let _guard = setup_logging(&config);
+    let _guard = setup_logging(&config.common_config);
 
     let client = XRPLClient::new(&config.xrpl_rpc, RETRIES as usize)?;
     let account = AccountId::from_address(&config.xrpl_multisig).unwrap();
 
-    let redis_client = redis::Client::open(config.redis_server.clone())?;
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone())?;
     let redis_pool = r2d2::Pool::builder().build(redis_client)?;
 
     setup_heartbeat("heartbeat:ticket_monitor".to_owned(), redis_pool);

--- a/xrpl/src/config.rs
+++ b/xrpl/src/config.rs
@@ -1,0 +1,15 @@
+use serde_derive::Deserialize;
+use relayer_base::config::{Config};
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct XRPLConfig {
+
+    #[serde(flatten)]
+    pub common_config: Config,
+
+    pub refund_manager_addresses: String,
+    pub includer_secrets: String,
+    pub xrpl_rpc: String,
+    pub xrpl_faucet_url: String,
+    pub xrpl_multisig: String,
+}

--- a/xrpl/src/funder.rs
+++ b/xrpl/src/funder.rs
@@ -1,9 +1,7 @@
 use reqwest::Client;
 use tracing::{error, info};
 use xrpl_api::{AccountInfoRequest, Amount};
-
-use relayer_base::config::Config;
-
+use super::config::XRPLConfig;
 use super::client::XRPLClient;
 
 const XRP_TOPUP_AMOUNT: u64 = 100;
@@ -12,11 +10,11 @@ const BALANCE_THRESHOLD: f64 = 100_000_000.0; // = 100 XRP
 pub struct XRPLFunder {
     request_client: Client,
     xrpl_client: XRPLClient,
-    config: Config,
+    config: XRPLConfig,
 }
 
 impl XRPLFunder {
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: XRPLConfig) -> Self {
         let request_client = Client::new();
         let xrpl_client = XRPLClient::new(&config.xrpl_rpc, 3).unwrap();
         Self {

--- a/xrpl/src/includer.rs
+++ b/xrpl/src/includer.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use relayer_base::{
-    config::Config, database::Database, error::BroadcasterError, gmp_api::GmpApi,
+    database::Database, error::BroadcasterError, gmp_api::GmpApi,
     includer::Includer, payload_cache::PayloadCache, queue::Queue,
 };
 
@@ -9,13 +9,14 @@ use super::{broadcaster::XRPLBroadcaster, client::XRPLClient, refund_manager::XR
 
 use error_stack;
 use r2d2;
+use super::config::XRPLConfig;
 
 pub struct XrplIncluder {}
 
 impl XrplIncluder {
     #[allow(clippy::new_ret_no_self)]
     pub async fn new<DB: Database>(
-        config: Config,
+        config: XRPLConfig,
         gmp_api: Arc<GmpApi>,
         redis_pool: r2d2::Pool<redis::Client>,
         payload_cache: PayloadCache<DB>,

--- a/xrpl/src/ingestor.rs
+++ b/xrpl/src/ingestor.rs
@@ -7,7 +7,6 @@ use relayer_base::ingestor::IngestorTrait;
 use relayer_base::models::task_retries::{PgTaskRetriesModel, TaskRetries};
 use relayer_base::subscriber::ChainTransaction;
 use relayer_base::{
-    config::Config,
     database::Database,
     error::{ITSTranslationError, IngestorError},
     gmp_api::{
@@ -44,7 +43,7 @@ use xrpl_amplifier_types::{
 use xrpl_api::Transaction;
 use xrpl_api::{Memo, PaymentTransaction};
 use xrpl_gateway::msg::{CallContract, InterchainTransfer, MessageWithPayload};
-
+use crate::config::XRPLConfig;
 use crate::utils::message_id_from_retry_task;
 use crate::xrpl_transaction::{PgXrplTransactionModel, XrplTransaction, XrplTransactionStatus};
 
@@ -58,7 +57,7 @@ pub struct XrplIngestorModels {
 pub struct XrplIngestor<DB: Database> {
     client: xrpl_http_client::Client,
     gmp_api: Arc<GmpApi>,
-    config: Config,
+    config: XRPLConfig,
     price_view: PriceView<DB>,
     payload_cache: PayloadCache<DB>,
     models: XrplIngestorModels,
@@ -67,7 +66,7 @@ pub struct XrplIngestor<DB: Database> {
 impl<DB: Database> XrplIngestor<DB> {
     pub fn new(
         gmp_api: Arc<GmpApi>,
-        config: Config,
+        config: XRPLConfig,
         price_view: PriceView<DB>,
         payload_cache: PayloadCache<DB>,
         models: XrplIngestorModels,
@@ -165,7 +164,7 @@ impl<DB: Database> XrplIngestor<DB> {
 
         let verify_tx_hash = self
             .gmp_api
-            .post_broadcast(self.config.axelar_contracts.xrpl_gateway.clone(), &request)
+            .post_broadcast(self.config.common_config.axelar_contracts.chain_gateway.clone(), &request)
             .await
             .map_err(|e| IngestorError::GenericError(e.to_string()))?;
 
@@ -274,7 +273,7 @@ impl<DB: Database> XrplIngestor<DB> {
 
                 let response_body = self
                     .gmp_api
-                    .post_query(self.config.axelar_contracts.xrpl_gateway.clone(), &request)
+                    .post_query(self.config.common_config.axelar_contracts.chain_gateway.clone(), &request)
                     .await
                     .map_err(|e| {
                         IngestorError::GenericError(format!("Failed to get token id: {}", e))
@@ -326,7 +325,7 @@ impl<DB: Database> XrplIngestor<DB> {
 
         let response_body = self
             .gmp_api
-            .post_query(self.config.axelar_contracts.xrpl_gateway.clone(), &request)
+            .post_query(self.config.common_config.axelar_contracts.chain_gateway.clone(), &request)
             .await
             .map_err(|e| ITSTranslationError::RequestError(e.to_string()))?;
 
@@ -457,6 +456,7 @@ impl<DB: Database> XrplIngestor<DB> {
                     XRPLPaymentAmount::Drops(amount) => {
                         let xrpl_token_id = self
                             .config
+                            .common_config
                             .deployed_tokens
                             .iter()
                             .find(|(_, token_symbol)| token_symbol == &"XRP")
@@ -477,7 +477,7 @@ impl<DB: Database> XrplIngestor<DB> {
                                 })?;
 
                             let amount = convert_token_amount_to_drops(
-                                &self.config,
+                                &self.config.common_config,
                                 amount,
                                 &token_id.to_string(),
                                 &self.price_view,
@@ -580,7 +580,7 @@ impl<DB: Database> XrplIngestor<DB> {
                     })?;
                     debug!("Token transfer: {:?}", msg_id);
                     convert_token_amount_to_drops(
-                        &self.config,
+                        &self.config.common_config,
                         amount,
                         &gas_token_id.to_string(),
                         &self.price_view,
@@ -630,7 +630,7 @@ impl<DB: Database> XrplIngestor<DB> {
                     e
                 ))
             })?);
-        Ok((self.config.axelar_contracts.xrpl_gateway.clone(), request))
+        Ok((self.config.common_config.axelar_contracts.chain_gateway.clone(), request))
     }
 
     pub async fn confirm_add_reserves_message_request(
@@ -648,7 +648,7 @@ impl<DB: Database> XrplIngestor<DB> {
                 ))
             })?);
         Ok((
-            self.config.axelar_contracts.xrpl_multisig_prover.clone(),
+            self.config.common_config.axelar_contracts.chain_multisig_prover.clone(),
             request,
         ))
     }
@@ -694,7 +694,7 @@ impl<DB: Database> XrplIngestor<DB> {
                 IngestorError::GenericError(format!("Failed to serialize ConfirmTxStatus: {}", e))
             })?);
         Ok((
-            self.config.axelar_contracts.xrpl_multisig_prover.clone(),
+            self.config.common_config.axelar_contracts.chain_multisig_prover.clone(),
             request,
         ))
     }
@@ -736,7 +736,7 @@ impl<DB: Database> XrplIngestor<DB> {
                     e
                 ))
             })?);
-        Ok((self.config.axelar_contracts.xrpl_gateway.clone(), request))
+        Ok((self.config.common_config.axelar_contracts.chain_gateway.clone(), request))
     }
 
     pub async fn handle_successful_routing(
@@ -1344,7 +1344,7 @@ impl<DB: Database> IngestorTrait for XrplIngestor<DB> {
         let maybe_construct_proof_tx_hash = self
             .gmp_api
             .post_broadcast(
-                self.config.axelar_contracts.xrpl_multisig_prover.clone(),
+                self.config.common_config.axelar_contracts.chain_multisig_prover.clone(),
                 &request,
             )
             .await

--- a/xrpl/src/lib.rs
+++ b/xrpl/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod broadcaster;
 pub mod client;
+pub mod config;
 pub mod funder;
 pub mod includer;
 pub mod ingestor;

--- a/xrpl/src/refund_manager.rs
+++ b/xrpl/src/refund_manager.rs
@@ -4,7 +4,6 @@ use libsecp256k1::{PublicKey, SecretKey};
 use rand::seq::SliceRandom;
 use redis::{Commands, ExistenceCheck, SetExpiry, SetOptions};
 use relayer_base::{
-    config::Config,
     error::RefundManagerError,
     gmp_api::gmp_types::RefundTask,
     includer::RefundManager,
@@ -13,18 +12,19 @@ use relayer_base::{
 use tracing::debug;
 use xrpl_binary_codec::{serialize, sign::sign_transaction};
 use xrpl_types::{AccountId, Amount, Blob, Memo, PaymentTransaction};
-
+use crate::config::XRPLConfig;
 use super::client::XRPLClient;
+
 pub struct XRPLRefundManager {
     client: Arc<XRPLClient>,
     redis_pool: r2d2::Pool<redis::Client>,
-    config: Config,
+    config: XRPLConfig,
 }
 
 impl XRPLRefundManager {
     pub fn new(
         client: Arc<XRPLClient>,
-        config: Config,
+        config: XRPLConfig,
         redis_pool: r2d2::Pool<redis::Client>,
     ) -> Result<Self, RefundManagerError> {
         Ok(Self {

--- a/xrpl/src/ticket_creator.rs
+++ b/xrpl/src/ticket_creator.rs
@@ -3,18 +3,18 @@ use std::sync::Arc;
 use tracing::{debug, error, info};
 
 use relayer_base::{
-    config::Config,
     gmp_api::{gmp_types::BroadcastRequest, GmpApi},
 };
 use xrpl_multisig_prover;
+use crate::config::XRPLConfig;
 
 pub struct XrplTicketCreator {
     gmp_api: Arc<GmpApi>,
-    config: Config,
+    config: XRPLConfig,
 }
 
 impl XrplTicketCreator {
-    pub fn new(gmp_api: Arc<GmpApi>, config: Config) -> Self {
+    pub fn new(gmp_api: Arc<GmpApi>, config: XRPLConfig) -> Self {
         Self { gmp_api, config }
     }
 
@@ -26,7 +26,7 @@ impl XrplTicketCreator {
         let res = self
             .gmp_api
             .post_broadcast(
-                self.config.axelar_contracts.xrpl_multisig_prover.clone(),
+                self.config.common_config.axelar_contracts.chain_multisig_prover.clone(),
                 &request,
             )
             .await;


### PR DESCRIPTION
Instead of using the same Config struct for all chains, we should have a separate struct per-chain, with a common struct for configuration options that relayer always needs. 

The build passes, and the tests pass, but I didn't extensively test all XRPL binaries. 