### PR TITLE
refactor: Decouple xrpl_types from subscriber

### DIFF
--- a/xrpl/src/bin/xrpl_subscriber.rs
+++ b/xrpl/src/bin/xrpl_subscriber.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         _ = sigint.recv()  => {},
         _ = sigterm.recv() => {},
-        _ = subscriber.run(account.to_address(), events_queue.clone()) => {},
+        _ = subscriber.run(account, events_queue.clone()) => {},
     }
 
     events_queue.close().await;

--- a/xrpl/src/subscriber.rs
+++ b/xrpl/src/subscriber.rs
@@ -52,6 +52,7 @@ impl<DB: Database> XrplSubscriber<DB> {
 
 impl<DB: Database> TransactionPoller for XrplSubscriber<DB> {
     type Transaction = Transaction;
+    type Account = AccountId;
 
     fn make_queue_item(&mut self, tx: Self::Transaction) -> ChainTransaction {
         ChainTransaction::Xrpl(tx)
@@ -63,7 +64,7 @@ impl<DB: Database> TransactionPoller for XrplSubscriber<DB> {
     ) -> Result<Vec<Self::Transaction>, anyhow::Error> {
         let transactions = self
             .client
-            .get_transactions_for_account(&account_id, self.latest_ledger as u32 + 1)
+            .get_transactions_for_account(&account_id, (self.latest_ledger + 1) as u32)
             .await?;
 
         let max_response_ledger = transactions


### PR DESCRIPTION
Food for thought - would it make sense to try to decouple xrpl_api::Transaction from relayer_base too? Does relayer_base need to know anything about potential chain implementations? @themicp @Deiadara 