### PR TITLE
refactor: payload_cache automock

### DIFF
--- a/relayer_base/src/includer.rs
+++ b/relayer_base/src/includer.rs
@@ -16,6 +16,7 @@ use crate::{
     payload_cache::PayloadCache,
     queue::{Queue, QueueItem},
 };
+use crate::payload_cache::PayloadCacheTrait;
 
 pub trait RefundManager {
     type Wallet;

--- a/relayer_base/src/payload_cache.rs
+++ b/relayer_base/src/payload_cache.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use router_api::CrossChainId;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
@@ -15,12 +16,23 @@ pub struct PayloadCache<DB: Database> {
     db: DB,
 }
 
+#[cfg_attr(test, mockall::automock)]
+pub trait PayloadCacheTrait {
+    fn get(&self, cc_id: CrossChainId) -> impl Future<Output = Result<Option<PayloadCacheValue>, anyhow::Error>>;
+    fn store(&self, cc_id: CrossChainId, value: PayloadCacheValue) -> impl Future<Output = Result<(), anyhow::Error>>;
+    fn clear(&self, cc_id: CrossChainId) -> impl Future<Output = Result<(), anyhow::Error>>;
+}
+
+
 impl<DB: Database> PayloadCache<DB> {
     pub fn new(db: DB) -> Self {
         Self { db }
     }
+}
 
-    pub async fn get(
+impl<DB: Database> PayloadCacheTrait for PayloadCache<DB> {
+
+    async fn get(
         &self,
         cc_id: CrossChainId,
     ) -> Result<Option<PayloadCacheValue>, anyhow::Error> {
@@ -40,7 +52,7 @@ impl<DB: Database> PayloadCache<DB> {
         }
     }
 
-    pub async fn store(
+    async fn store(
         &self,
         cc_id: CrossChainId,
         value: PayloadCacheValue,
@@ -55,7 +67,7 @@ impl<DB: Database> PayloadCache<DB> {
         Ok(())
     }
 
-    pub async fn clear(&self, cc_id: CrossChainId) -> Result<(), anyhow::Error> {
+    async fn clear(&self, cc_id: CrossChainId) -> Result<(), anyhow::Error> {
         debug!("Clearing payload cache for {}", cc_id);
         self.db
             .clear_payload(cc_id)
@@ -63,5 +75,91 @@ impl<DB: Database> PayloadCache<DB> {
             .map_err(|e| anyhow::anyhow!("Failed to clear payload: {}", e))?;
 
         Ok(())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::MockDatabase;
+    use crate::gmp_api::gmp_types::GatewayV2Message;
+    use mockall::predicate::*;
+    use tokio;
+
+    #[tokio::test]
+    async fn test_store() {
+        let mut mock_db = MockDatabase::new();
+        let cc_id = CrossChainId::new("foo", "bar").unwrap();
+        let message = GatewayV2Message {
+            message_id: "message".to_string(),
+            source_chain: "source chain".to_string(),
+            source_address: "source address".to_string(),
+            destination_address: "destination address".to_string(),
+            payload_hash: "payload hash".to_string(),
+        };
+        let value = PayloadCacheValue {
+            message: message.clone(),
+            payload: "test_payload".into(),
+        };
+        let serialized = serde_json::to_string(&value).unwrap();
+
+        mock_db
+            .expect_store_payload()
+            .with(eq(cc_id.clone()), eq(serialized.to_string()))
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+
+        let cache = PayloadCache::new(mock_db);
+        let result = cache.store(cc_id, value).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_existing_hit() {
+        let mut mock_db = MockDatabase::new();
+        let cc_id = CrossChainId::new("foo", "bar").unwrap();
+        let message = GatewayV2Message {
+            message_id: "message".to_string(),
+            source_chain: "source chain".to_string(),
+            source_address: "source address".to_string(),
+            destination_address: "destination address".to_string(),
+            payload_hash: "payload hash".to_string(),
+        };
+        let value = PayloadCacheValue {
+            message: message.clone(),
+            payload: "test_payload".into(),
+        };
+        let serialized = serde_json::to_string(&value).unwrap();
+        mock_db
+            .expect_get_payload()
+            .with(eq(cc_id.clone()))
+            .returning(move |_| {
+                let result = Some(serialized.clone());
+                Box::pin(async move { Ok(result) })
+            });
+
+        let cache = PayloadCache::new(mock_db);
+        let result = cache.get(cc_id).await.unwrap();
+
+        assert_eq!(result, Some(value));
+    }
+
+    #[tokio::test]
+    async fn test_get_existing_miss() {
+        let mut mock_db = MockDatabase::new();
+        let cc_id = CrossChainId::new("foo", "bar").unwrap();
+
+        mock_db
+            .expect_get_payload()
+            .with(eq(cc_id.clone()))
+            .returning(move |_| {
+                Box::pin(async move { Ok(None) })
+            });
+
+        let cache = PayloadCache::new(mock_db);
+        let result = cache.get(cc_id).await.unwrap();
+
+        assert_eq!(result, None);
     }
 }

--- a/relayer_base/src/proof_retrier.rs
+++ b/relayer_base/src/proof_retrier.rs
@@ -1,3 +1,4 @@
+use crate::payload_cache::PayloadCacheTrait;
 use std::sync::Arc;
 
 use async_std::stream::StreamExt;

--- a/xrpl/src/ingestor.rs
+++ b/xrpl/src/ingestor.rs
@@ -43,6 +43,7 @@ use xrpl_amplifier_types::{
 use xrpl_api::Transaction;
 use xrpl_api::{Memo, PaymentTransaction};
 use xrpl_gateway::msg::{CallContract, InterchainTransfer, MessageWithPayload};
+use relayer_base::payload_cache::PayloadCacheTrait;
 use crate::config::XRPLConfig;
 use crate::utils::message_id_from_retry_task;
 use crate::xrpl_transaction::{PgXrplTransactionModel, XrplTransaction, XrplTransactionStatus};


### PR DESCRIPTION
It's not urgent to merge this in - I will have it in ton branch, but just so @Deiadara and I don't cover the same ground with testing. I needed to have payload cache in trait so I can use it for ton development.