### PR TITLE
Fix/error handling

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,8 +27,11 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Run Clippy
-        run: cargo clippy --all-targets --workspace -- -D warnings
+      - name: Clippy on library & bins
+        run: cargo clippy --workspace --bins --lib -- -D warnings
+
+      - name: Clippy on tests
+        run: cargo clippy --workspace --tests -- -D warnings -A clippy::unwrap_used
 
       - name: Run tests
         run: cargo test --workspace

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,11 +27,8 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Clippy on library & bins
-        run: cargo clippy --workspace --bins --lib -- -D warnings
-
-      - name: Clippy on tests
-        run: cargo clippy --workspace --tests -- -D warnings -A clippy::unwrap_used
+      - name: Clippy on entire codebase
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Run tests
         run: cargo test --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ testcontainers-modules = { version = "0.12.1", features = ["postgres"] }
 uninlined_format_args = "allow"
 unwrap_used = "warn"
 indexing_slicing = "warn"
-clone_on_ref_ptr = "allow"
+clone_on_ref_ptr = "warn"
 redundant_clone = "warn"
 unnecessary_box_returns = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,11 @@ testcontainers-modules = { version = "0.12.1", features = ["postgres"] }
 [workspace.lints.clippy]
 uninlined_format_args = "allow"
 unwrap_used = "allow"
-expect_used = "allow"
-panic = "allow"
+
 indexing_slicing = "allow"
 clone_on_ref_ptr = "allow"
 redundant_clone = "allow"
 unnecessary_box_returns = "allow"
+
+# TODO: See if we can seperate warnings on tests
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,10 +63,11 @@ testcontainers-modules = { version = "0.12.1", features = ["postgres"] }
 # switch between warn and allow to enable/disable more restrictive clippy lints
 [workspace.lints.clippy]
 uninlined_format_args = "allow"
-unwrap_used = "allow"
+unwrap_used = "warn"
 expect_used = "allow"
 panic = "allow"
 indexing_slicing = "allow"
 clone_on_ref_ptr = "allow"
 redundant_clone = "allow"
 unnecessary_box_returns = "allow"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ testcontainers-modules = { version = "0.12.1", features = ["postgres"] }
 # switch between warn and allow to enable/disable more restrictive clippy lints
 [workspace.lints.clippy]
 uninlined_format_args = "allow"
-unwrap_used = "allow"
+unwrap_used = "warn"
 
 indexing_slicing = "allow"
 clone_on_ref_ptr = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ testcontainers-modules = { version = "0.12.1", features = ["postgres"] }
 # switch between warn and allow to enable/disable more restrictive clippy lints
 [workspace.lints.clippy]
 uninlined_format_args = "allow"
-unwrap_used = "warn"
+unwrap_used = "allow"
 expect_used = "allow"
 panic = "allow"
 indexing_slicing = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,8 @@ testcontainers-modules = { version = "0.12.1", features = ["postgres"] }
 [workspace.lints.clippy]
 uninlined_format_args = "allow"
 unwrap_used = "warn"
-
-indexing_slicing = "allow"
+indexing_slicing = "warn"
 clone_on_ref_ptr = "allow"
-redundant_clone = "allow"
-unnecessary_box_returns = "allow"
-
-# TODO: See if we can seperate warnings on tests
+redundant_clone = "warn"
+unnecessary_box_returns = "warn"
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+allow-unwrap-in-tests = true
+allow-panic-in-tests = true
+allow-indexing-slicing-in-tests = true

--- a/recovery_tools/src/bin/proof_retrier.rs
+++ b/recovery_tools/src/bin/proof_retrier.rs
@@ -9,6 +9,7 @@ use relayer_base::{
     queue::Queue,
     utils::{setup_heartbeat, setup_logging},
 };
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -26,8 +27,8 @@ async fn main() -> anyhow::Result<()> {
     let redis_pool = r2d2::Pool::builder().build(redis_client)?;
     let proof_retrier = ProofRetrier::new(
         payload_cache,
-        construct_proof_queue.clone(),
-        tasks_queue.clone(),
+        Arc::clone(&construct_proof_queue),
+        Arc::clone(&tasks_queue),
         redis_pool.clone(),
     );
 

--- a/recovery_tools/src/bin/proof_retrier.rs
+++ b/recovery_tools/src/bin/proof_retrier.rs
@@ -14,16 +14,16 @@ use relayer_base::{
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config: Config = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: Config = config_from_yaml(&format!("config.{}.yaml", network))?;
 
     let _guard = setup_logging(&config);
 
     let construct_proof_queue = Queue::new(&config.queue_address, "construct_proof").await;
     let tasks_queue = Queue::new(&config.queue_address, "ingestor_tasks").await;
-    let postgres_db = PostgresDB::new(&config.postgres_url).await.unwrap();
+    let postgres_db = PostgresDB::new(&config.postgres_url).await?;
     let payload_cache = PayloadCache::new(postgres_db);
-    let redis_client = redis::Client::open(config.redis_server.clone()).unwrap();
-    let redis_pool = r2d2::Pool::builder().build(redis_client).unwrap();
+    let redis_client = redis::Client::open(config.redis_server.clone())?;
+    let redis_pool = r2d2::Pool::builder().build(redis_client)?;
     let proof_retrier = ProofRetrier::new(
         payload_cache,
         construct_proof_queue.clone(),

--- a/relayer_base/src/bin/scripts/queue_migration.rs
+++ b/relayer_base/src/bin/scripts/queue_migration.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
         match maybe_delivery {
             Ok(delivery) => {
                 let data = delivery.data.clone();
-                let task_item: QueueItem = serde_json::from_slice::<QueueItem>(&data).unwrap();
+                let task_item: QueueItem = serde_json::from_slice::<QueueItem>(&data)?;
                 let task = match task_item.clone() {
                     QueueItem::Task(task) => task,
                     _ => continue,
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
                     | TaskKind::ReactToExpiredSigningSession => ingestor_tasks_queue.clone(),
                     TaskKind::Unknown | TaskKind::Execute => {
                         warn!("Dropping and acking unknown task: {:?}", task);
-                        delivery.ack(BasicAckOptions::default()).await.unwrap();
+                        delivery.ack(BasicAckOptions::default()).await?;
                         continue;
                     }
                 };

--- a/relayer_base/src/bin/scripts/queue_migration.rs
+++ b/relayer_base/src/bin/scripts/queue_migration.rs
@@ -9,6 +9,7 @@ use relayer_base::{
     utils::setup_logging,
 };
 use std::env;
+use std::sync::Arc;
 use tracing::{error, info, warn};
 
 #[tokio::main]
@@ -42,12 +43,12 @@ async fn main() -> Result<()> {
                 };
                 info!("Publishing task: {:?}", task);
                 let queue = match task.kind() {
-                    TaskKind::Refund | TaskKind::GatewayTx => includer_tasks_queue.clone(),
+                    TaskKind::Refund | TaskKind::GatewayTx => Arc::clone(&includer_tasks_queue),
                     TaskKind::Verify
                     | TaskKind::ConstructProof
                     | TaskKind::ReactToWasmEvent
                     | TaskKind::ReactToRetriablePoll
-                    | TaskKind::ReactToExpiredSigningSession => ingestor_tasks_queue.clone(),
+                    | TaskKind::ReactToExpiredSigningSession => Arc::clone(&ingestor_tasks_queue),
                     TaskKind::Unknown | TaskKind::Execute => {
                         warn!("Dropping and acking unknown task: {:?}", task);
                         delivery.ack(BasicAckOptions::default()).await?;

--- a/relayer_base/src/distributor.rs
+++ b/relayer_base/src/distributor.rs
@@ -33,8 +33,7 @@ impl<DB: Database> Distributor<DB> {
 
         info!(
             "Distributor: recovering last task id from {}: {:?}",
-            context,
-            last_task_id.clone()
+            context, last_task_id
         );
 
         Self {

--- a/relayer_base/src/distributor.rs
+++ b/relayer_base/src/distributor.rs
@@ -55,12 +55,12 @@ impl<DB: Database> Distributor<DB> {
         gmp_api: Arc<GmpApi>,
         recovery_settings: RecoverySettings,
         refunds_enabled: bool,
-    ) -> Self {
+    ) -> Result<Self, DistributorError> {
         let mut distributor = Self::new(db, context, gmp_api, refunds_enabled).await;
         distributor.recovery_settings = Some(recovery_settings.clone());
         distributor.last_task_id = recovery_settings.from_task_id;
-        distributor.store_last_task_id().await.unwrap();
-        distributor
+        distributor.store_last_task_id().await?;
+        Ok(distributor)
     }
 
     async fn store_last_task_id(&mut self) -> Result<(), DistributorError> {

--- a/relayer_base/src/gmp_api/gmp_types.rs
+++ b/relayer_base/src/gmp_api/gmp_types.rs
@@ -199,7 +199,7 @@ pub struct RefundTask {
 
 impl fmt::Display for VerificationStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", serde_json::to_string(self).unwrap())
+        write!(f, "{:?}", serde_json::to_string(self).unwrap_or_default())
     }
 }
 

--- a/relayer_base/src/includer.rs
+++ b/relayer_base/src/includer.rs
@@ -136,7 +136,7 @@ where
         if let Ok(mut consumer) = queue.consumer().await {
             loop {
                 info!("Includer is alive.");
-                self.work(&mut consumer, queue.clone()).await;
+                self.work(&mut consumer, Arc::clone(&queue)).await;
             }
         } else {
             error!("Failed to create consumer");

--- a/relayer_base/src/ingestor.rs
+++ b/relayer_base/src/ingestor.rs
@@ -105,10 +105,10 @@ impl<I: IngestorTrait> Ingestor<I> {
         info!("Ingestor is alive.");
 
         select! {
-            _ = self.work(&mut events_consumer, events_queue.clone()) => {
+            _ = self.work(&mut events_consumer, Arc::clone(&events_queue)) => {
                 warn!("Events consumer ended");
             },
-            _ = self.work(&mut tasks_consumer, tasks_queue.clone()) => {
+            _ = self.work(&mut tasks_consumer, Arc::clone(&tasks_queue)) => {
                 warn!("Tasks consumer ended");
             }
         };

--- a/relayer_base/src/ingestor.rs
+++ b/relayer_base/src/ingestor.rs
@@ -152,12 +152,12 @@ impl<I: IngestorTrait> Ingestor<I> {
 
         for event_response in response {
             if event_response.status != "ACCEPTED" {
-                error!("Posting event failed: {:?}", event_response.error.clone());
+                error!("Posting event failed: {:?}", event_response.error);
                 if let Some(true) = event_response.retriable {
                     return Err(IngestorError::RetriableError(
                         // TODO: retry? Handle error responses for part of the batch
                         // Question: what happens if we send the same event multiple times?
-                        event_response.error.clone().unwrap_or_default(),
+                        event_response.error.unwrap_or_default(),
                     ));
                 }
             }

--- a/relayer_base/src/proof_retrier.rs
+++ b/relayer_base/src/proof_retrier.rs
@@ -57,12 +57,14 @@ impl<DB: Database> ProofRetrier<DB> {
             .get(redis_key.clone())
             .map_err(|e| anyhow::anyhow!("Failed to get Redis key: {}", e))?;
 
-        if redis_value.is_some() && redis_value.unwrap() >= 10 {
-            debug!("Message {} has failed too many times, skipping", cc_id);
-            return Err(anyhow::anyhow!(
-                "Message {} has failed too many times",
-                cc_id
-            ));
+        if let Some(value) = redis_value {
+            if value >= 10 {
+                debug!("Message {} has failed too many times, skipping", cc_id);
+                return Err(anyhow::anyhow!(
+                    "Message {} has failed too many times",
+                    cc_id
+                ));
+            }
         }
 
         let source_chain = cc_id

--- a/relayer_base/src/queue.rs
+++ b/relayer_base/src/queue.rs
@@ -81,10 +81,10 @@ impl BufferProcessor {
     }
 
     fn run(&mut self) {
-        let receiver_mutex = self.buffer_receiver.clone();
-        let sender = self.buffer_sender.clone();
-        let queue = self.queue.clone();
-        let shutdown_signal = self.shutdown_signal.clone();
+        let receiver_mutex = Arc::clone(&self.buffer_receiver);
+        let sender = Arc::clone(&self.buffer_sender);
+        let queue = Arc::clone(&self.queue);
+        let shutdown_signal = Arc::clone(&self.shutdown_signal);
         let cancellation_token = self.cancellation_token.clone();
         self.handle = Some(tokio::spawn(async move {
             loop {
@@ -145,14 +145,14 @@ impl Queue {
         });
 
         let mut processor = BufferProcessor::new(
-            queue_arc.buffer_sender.clone(),
+            Arc::clone(&queue_arc.buffer_sender),
             buffer_receiver,
-            queue_arc.clone(),
+            Arc::clone(&queue_arc),
         );
         processor.run();
         *queue_arc.buffer_processor.write().await = Some(processor);
 
-        let queue_clone = queue_arc.clone();
+        let queue_clone = Arc::clone(&queue_arc);
         tokio::spawn(async move {
             queue_clone.connection_health_check().await;
         });

--- a/relayer_base/src/subscriber.rs
+++ b/relayer_base/src/subscriber.rs
@@ -81,7 +81,7 @@ where
 
     pub async fn run(&mut self, account: TP::Account, queue: Arc<Queue>) {
         loop {
-            self.work(account.clone(), queue.clone()).await;
+            self.work(account.clone(), Arc::clone(&queue)).await;
         }
     }
 

--- a/relayer_base/src/utils.rs
+++ b/relayer_base/src/utils.rs
@@ -307,7 +307,7 @@ where
                     )
                 })?,
                 None => {
-                    return Err(db_err.into());
+                    return Err(db_err);
                 }
             }
         }

--- a/relayer_base/src/utils.rs
+++ b/relayer_base/src/utils.rs
@@ -103,7 +103,7 @@ pub fn extract_hex_xrpl_memo(
     memos: Option<Vec<Memo>>,
     memo_type: &str,
 ) -> Result<String, anyhow::Error> {
-    let hex_str = extract_from_xrpl_memo(memos.clone(), memo_type)?;
+    let hex_str = extract_from_xrpl_memo(memos, memo_type)?;
     let bytes = hex::decode(&hex_str)?;
     String::from_utf8(bytes).map_err(|e| e.into())
 }
@@ -115,7 +115,7 @@ pub fn setup_logging(config: &Config) -> ClientInitGuard {
         config.sentry_dsn.to_string(),
         sentry::ClientOptions {
             release: sentry::release_name!(),
-            environment: Some(std::borrow::Cow::Owned(environment.clone())),
+            environment: Some(std::borrow::Cow::Owned(environment)),
             traces_sample_rate: 1.0,
             ..Default::default()
         },

--- a/xrpl/src/bin/recovery/xrpl_subscriber_recovery.rs
+++ b/xrpl/src/bin/recovery/xrpl_subscriber_recovery.rs
@@ -7,6 +7,7 @@ use relayer_base::{
     subscriber::Subscriber,
     utils::{setup_heartbeat, setup_logging},
 };
+use std::sync::Arc;
 use tokio::signal::unix::{signal, SignalKind};
 use xrpl::{client::XRPLClient, config::XRPLConfig, subscriber::XrplSubscriber};
 
@@ -55,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
         _ = sigterm.recv() => {},
         _ = subscriber.recover_txs(
             txs.into_iter().map(|s| s.to_string()).collect(),
-            events_queue.clone(),
+            Arc::clone(&events_queue),
         ) => {},
 
     }

--- a/xrpl/src/bin/recovery/xrpl_task_recovery.rs
+++ b/xrpl/src/bin/recovery/xrpl_task_recovery.rs
@@ -50,8 +50,8 @@ async fn main() -> anyhow::Result<()> {
         _ = sigint.recv()  => {},
         _ = sigterm.recv() => {},
         _ = distributor.run_recovery(
-            includer_tasks_queue.clone(),
-            ingestor_tasks_queue.clone(),
+            Arc::clone(&includer_tasks_queue),
+            Arc::clone(&ingestor_tasks_queue),
         ) => {},
     }
 

--- a/xrpl/src/bin/recovery/xrpl_task_recovery.rs
+++ b/xrpl/src/bin/recovery/xrpl_task_recovery.rs
@@ -16,7 +16,7 @@ use xrpl::config::XRPLConfig;
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network))?;
 
     let _guard = setup_logging(&config.common_config);
 
@@ -24,10 +24,8 @@ async fn main() -> anyhow::Result<()> {
         Queue::new(&config.common_config.queue_address, "includer_tasks").await;
     let ingestor_tasks_queue =
         Queue::new(&config.common_config.queue_address, "ingestor_tasks").await;
-    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, true).unwrap());
-    let postgres_db = PostgresDB::new(&config.common_config.postgres_url)
-        .await
-        .unwrap();
+    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, true)?);
+    let postgres_db = PostgresDB::new(&config.common_config.postgres_url).await?;
 
     let mut distributor = Distributor::new_with_recovery_settings(
         postgres_db,
@@ -43,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
         },
         config.common_config.refunds_enabled,
     )
-    .await;
+    .await?;
 
     let mut sigint = signal(SignalKind::interrupt())?;
     let mut sigterm = signal(SignalKind::terminate())?;

--- a/xrpl/src/bin/xrpl_distributor.rs
+++ b/xrpl/src/bin/xrpl_distributor.rs
@@ -52,8 +52,8 @@ async fn main() -> anyhow::Result<()> {
         _ = sigint.recv()  => {},
         _ = sigterm.recv() => {},
         _ = distributor.run(
-            includer_tasks_queue.clone(),
-            ingestor_tasks_queue.clone(),
+            Arc::clone(&includer_tasks_queue),
+            Arc::clone(&ingestor_tasks_queue),
         ) => {},
     }
 

--- a/xrpl/src/bin/xrpl_distributor.rs
+++ b/xrpl/src/bin/xrpl_distributor.rs
@@ -16,7 +16,7 @@ use xrpl::config::XRPLConfig;
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network))?;
 
     let _guard = setup_logging(&config.common_config);
 
@@ -40,8 +40,8 @@ async fn main() -> anyhow::Result<()> {
     let mut sigint = signal(SignalKind::interrupt())?;
     let mut sigterm = signal(SignalKind::terminate())?;
 
-    let redis_client = redis::Client::open(config.common_config.redis_server.clone()).unwrap();
-    let redis_pool = r2d2::Pool::builder().build(redis_client).unwrap();
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone())?;
+    let redis_pool = r2d2::Pool::builder().build(redis_client)?;
 
     setup_heartbeat("heartbeat:distributor".to_owned(), redis_pool);
 

--- a/xrpl/src/bin/xrpl_distributor.rs
+++ b/xrpl/src/bin/xrpl_distributor.rs
@@ -24,10 +24,13 @@ async fn main() -> anyhow::Result<()> {
         Queue::new(&config.common_config.queue_address, "includer_tasks").await;
     let ingestor_tasks_queue =
         Queue::new(&config.common_config.queue_address, "ingestor_tasks").await;
-    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, true).unwrap());
+    let gmp_api = Arc::new(
+        gmp_api::GmpApi::new(&config.common_config, true)
+            .map_err(|e| anyhow::anyhow!("Failed to create GmpApi: {}", e))?,
+    );
     let postgres_db = PostgresDB::new(&config.common_config.postgres_url)
         .await
-        .unwrap();
+        .map_err(|e| anyhow::anyhow!("Failed to create PostgresDB: {}", e))?;
 
     let mut distributor = Distributor::new(
         postgres_db,

--- a/xrpl/src/bin/xrpl_funder.rs
+++ b/xrpl/src/bin/xrpl_funder.rs
@@ -7,19 +7,21 @@ use relayer_base::utils::{setup_heartbeat, setup_logging};
 use xrpl::config::XRPLConfig;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network))?;
 
     let _guard = setup_logging(&config.common_config);
 
-    let redis_client = redis::Client::open(config.common_config.redis_server.clone()).unwrap();
-    let redis_pool = r2d2::Pool::builder().build(redis_client).unwrap();
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone())?;
+    let redis_pool = r2d2::Pool::builder().build(redis_client)?;
 
     setup_heartbeat("heartbeat:funder".to_owned(), redis_pool);
 
-    let xrpl_client = XRPLClient::new(&config.xrpl_rpc, 3).unwrap();
+    let xrpl_client = XRPLClient::new(&config.xrpl_rpc, 3)?;
     let funder = XRPLFunder::new(config, xrpl_client);
     funder.run().await;
+
+    Ok(())
 }

--- a/xrpl/src/bin/xrpl_heartbeat_monitor.rs
+++ b/xrpl/src/bin/xrpl_heartbeat_monitor.rs
@@ -24,7 +24,7 @@ async fn main() -> anyhow::Result<()> {
 
         for (key, url) in config.common_config.heartbeats.iter() {
             let redis_key = format!("heartbeat:{}", key);
-            let mut redis_conn = redis_pool.get().unwrap();
+            let mut redis_conn = redis_pool.get()?;
             if redis_conn.get(redis_key).unwrap_or(0) == 1 {
                 match client.get(url).send().await {
                     Ok(response) => {

--- a/xrpl/src/bin/xrpl_includer.rs
+++ b/xrpl/src/bin/xrpl_includer.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
         gmp_api,
         redis_pool.clone(),
         payload_cache,
-        construct_proof_queue.clone(),
+        Arc::clone(&construct_proof_queue),
         queued_tx_model.clone(),
         Arc::new(xrpl_client),
     )
@@ -55,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         _ = sigint.recv()  => {},
         _ = sigterm.recv() => {},
-        _ = xrpl_includer.run(tasks_queue.clone()) => {},
+        _ = xrpl_includer.run(Arc::clone(&tasks_queue)) => {},
     }
 
     tasks_queue.close().await;

--- a/xrpl/src/bin/xrpl_ingestor.rs
+++ b/xrpl/src/bin/xrpl_ingestor.rs
@@ -25,19 +25,15 @@ use xrpl::config::XRPLConfig;
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network))?;
 
     let _guard = setup_logging(&config.common_config);
 
     let tasks_queue = Queue::new(&config.common_config.queue_address, "ingestor_tasks").await;
     let events_queue = Queue::new(&config.common_config.queue_address, "events").await;
-    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, true).unwrap());
-    let postgres_db = PostgresDB::new(&config.common_config.postgres_url)
-        .await
-        .unwrap();
-    let pg_pool = PgPool::connect(&config.common_config.postgres_url)
-        .await
-        .unwrap();
+    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, true)?);
+    let postgres_db = PostgresDB::new(&config.common_config.postgres_url).await?;
+    let pg_pool = PgPool::connect(&config.common_config.postgres_url).await?;
     let price_view = PriceView::new(postgres_db.clone());
     let payload_cache = PayloadCache::new(postgres_db.clone());
     let models = XrplIngestorModels {

--- a/xrpl/src/bin/xrpl_ingestor.rs
+++ b/xrpl/src/bin/xrpl_ingestor.rs
@@ -42,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
     };
     // make an xrpl ingestor
     let xrpl_ingestor = XrplIngestor::new(
-        gmp_api.clone(),
+        Arc::clone(&gmp_api),
         config.clone(),
         price_view,
         payload_cache,
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         _ = sigint.recv()  => {},
         _ = sigterm.recv() => {},
-        _ = ingestor.run(events_queue.clone(), tasks_queue.clone()) => {},
+        _ = ingestor.run(Arc::clone(&events_queue), Arc::clone(&tasks_queue)) => {},
     }
 
     tasks_queue.close().await;

--- a/xrpl/src/bin/xrpl_queued_tx_monitor.rs
+++ b/xrpl/src/bin/xrpl_queued_tx_monitor.rs
@@ -16,13 +16,11 @@ use xrpl::{
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network))?;
 
     let _guard = setup_logging(&config.common_config);
 
-    let pg_pool = PgPool::connect(&config.common_config.postgres_url)
-        .await
-        .unwrap();
+    let pg_pool = PgPool::connect(&config.common_config.postgres_url).await?;
     let xrpl_client = Arc::new(XRPLClient::new(&config.xrpl_rpc, 3)?);
     let queued_tx_model = PgQueuedTransactionsModel::new(pg_pool);
 

--- a/xrpl/src/bin/xrpl_subscriber.rs
+++ b/xrpl/src/bin/xrpl_subscriber.rs
@@ -7,6 +7,7 @@ use relayer_base::{
     subscriber::Subscriber,
     utils::{setup_heartbeat, setup_logging},
 };
+use std::sync::Arc;
 use tokio::signal::unix::{signal, SignalKind};
 use xrpl::{client::XRPLClient, config::XRPLConfig, subscriber::XrplSubscriber};
 use xrpl_types::AccountId;
@@ -39,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         _ = sigint.recv()  => {},
         _ = sigterm.recv() => {},
-        _ = subscriber.run(account, events_queue.clone()) => {},
+        _ = subscriber.run(account, Arc::clone(&events_queue)) => {},
     }
 
     events_queue.close().await;

--- a/xrpl/src/bin/xrpl_subscriber.rs
+++ b/xrpl/src/bin/xrpl_subscriber.rs
@@ -15,18 +15,16 @@ use xrpl_types::AccountId;
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network))?;
 
     let _guard = setup_logging(&config.common_config);
 
     let events_queue = Queue::new(&config.common_config.queue_address, "events").await;
-    let postgres_db = PostgresDB::new(&config.common_config.postgres_url)
-        .await
-        .unwrap();
+    let postgres_db = PostgresDB::new(&config.common_config.postgres_url).await?;
 
-    let account = AccountId::from_address(&config.xrpl_multisig).unwrap();
+    let account = AccountId::from_address(&config.xrpl_multisig)?;
 
-    let xrpl_client = XRPLClient::new(&config.xrpl_rpc, 3).unwrap();
+    let xrpl_client = XRPLClient::new(&config.xrpl_rpc, 3)?;
     let xrpl_subscriber =
         XrplSubscriber::new(xrpl_client, postgres_db, "default".to_string()).await?;
     let mut subscriber = Subscriber::new(xrpl_subscriber);

--- a/xrpl/src/bin/xrpl_ticket_creator.rs
+++ b/xrpl/src/bin/xrpl_ticket_creator.rs
@@ -10,19 +10,21 @@ use xrpl::config::XRPLConfig;
 use xrpl::ticket_creator::XrplTicketCreator;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     let network = std::env::var("NETWORK").expect("NETWORK must be set");
-    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network)).unwrap();
+    let config: XRPLConfig = config_from_yaml(&format!("config.{}.yaml", network))?;
 
     let _guard = setup_logging(&config.common_config);
 
-    let redis_client = redis::Client::open(config.common_config.redis_server.clone()).unwrap();
-    let redis_pool = r2d2::Pool::builder().build(redis_client).unwrap();
+    let redis_client = redis::Client::open(config.common_config.redis_server.clone())?;
+    let redis_pool = r2d2::Pool::builder().build(redis_client)?;
 
     setup_heartbeat("heartbeat:ticket_creator".to_owned(), redis_pool);
 
     let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, false).unwrap());
     let ticket_creator = XrplTicketCreator::new(gmp_api.clone(), config.clone());
     ticket_creator.run().await;
+
+    Ok(())
 }

--- a/xrpl/src/bin/xrpl_ticket_creator.rs
+++ b/xrpl/src/bin/xrpl_ticket_creator.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
         gmp_api::GmpApi::new(&config.common_config, false)
             .map_err(|e| anyhow::anyhow!("Failed to create GmpApi: {}", e))?,
     );
-    let ticket_creator = XrplTicketCreator::new(gmp_api.clone(), config.clone());
+    let ticket_creator = XrplTicketCreator::new(Arc::clone(&gmp_api), config.clone());
     ticket_creator.run().await;
 
     Ok(())

--- a/xrpl/src/bin/xrpl_ticket_creator.rs
+++ b/xrpl/src/bin/xrpl_ticket_creator.rs
@@ -22,7 +22,10 @@ async fn main() -> anyhow::Result<()> {
 
     setup_heartbeat("heartbeat:ticket_creator".to_owned(), redis_pool);
 
-    let gmp_api = Arc::new(gmp_api::GmpApi::new(&config.common_config, false).unwrap());
+    let gmp_api = Arc::new(
+        gmp_api::GmpApi::new(&config.common_config, false)
+            .map_err(|e| anyhow::anyhow!("Failed to create GmpApi: {}", e))?,
+    );
     let ticket_creator = XrplTicketCreator::new(gmp_api.clone(), config.clone());
     ticket_creator.run().await;
 

--- a/xrpl/src/bin/xrpl_ticket_monitor.rs
+++ b/xrpl/src/bin/xrpl_ticket_monitor.rs
@@ -20,7 +20,7 @@ async fn main() -> anyhow::Result<()> {
     let _guard = setup_logging(&config.common_config);
 
     let client = XRPLClient::new(&config.xrpl_rpc, RETRIES as usize)?;
-    let account = AccountId::from_address(&config.xrpl_multisig).unwrap();
+    let account = AccountId::from_address(&config.xrpl_multisig)?;
 
     let redis_client = redis::Client::open(config.common_config.redis_server.clone())?;
     let redis_pool = r2d2::Pool::builder().build(redis_client)?;

--- a/xrpl/src/broadcaster.rs
+++ b/xrpl/src/broadcaster.rs
@@ -93,7 +93,7 @@ impl<QM: QueuedTransactionsModel, X: XRPLClientTrait> Broadcaster for XRPLBroadc
                     .map_err(|e| BroadcasterError::GenericError(e.to_string()))?,
             );
             source_chain = Some(
-                extract_hex_xrpl_memo(memos.clone(), "source_chain")
+                extract_hex_xrpl_memo(memos, "source_chain")
                     .map_err(|e| BroadcasterError::GenericError(e.to_string()))?,
             );
         }

--- a/xrpl/src/client.rs
+++ b/xrpl/src/client.rs
@@ -108,7 +108,7 @@ impl XRPLClientTrait for XRPLClient {
         let request = xrpl_api::TxRequest::new(&tx_id);
         let res = self.call(request).await;
         let response = res.map_err(|e| anyhow!("Error getting txs: {:?}", e.to_string()))?;
-        Ok(response.tx.clone())
+        Ok(response.tx)
     }
 
     async fn get_transactions_for_account(

--- a/xrpl/src/funder.rs
+++ b/xrpl/src/funder.rs
@@ -40,8 +40,9 @@ impl<X: XRPLClientTrait> XRPLFunder<X> {
             Ok(resp) => {
                 let result: serde_json::Value =
                     resp.json().await.map_err(|e| anyhow::anyhow!(e))?;
-                let transaction_hash = result["transactionHash"]
-                    .as_str()
+                let transaction_hash = result
+                    .get("transactionHash")
+                    .and_then(|v| v.as_str())
                     .ok_or(anyhow::anyhow!("transactionHash not found in {:?}", result))?;
                 Ok(transaction_hash.to_string())
             }

--- a/xrpl/src/includer.rs
+++ b/xrpl/src/includer.rs
@@ -43,7 +43,7 @@ impl XrplIncluder {
             gmp_api,
             payload_cache,
             construct_proof_queue,
-            redis_pool: redis_pool.clone(),
+            redis_pool,
         };
 
         Ok(includer)

--- a/xrpl/src/ingestor.rs
+++ b/xrpl/src/ingestor.rs
@@ -756,7 +756,9 @@ impl<DB: Database> XrplIngestor<DB> {
         if payload_hash.is_some() {
             let payload_string = self
                 .gmp_api
-                .get_payload(&hex::encode(payload_hash.unwrap()))
+                .get_payload(&hex::encode(payload_hash.ok_or(
+                    IngestorError::GenericError("Payload hash is None".to_owned()),
+                )?))
                 .await
                 .map_err(|e| {
                     IngestorError::GenericError(format!("Failed to get payload from cache: {}", e))
@@ -800,7 +802,9 @@ impl<DB: Database> XrplIngestor<DB> {
     ) -> Result<(), IngestorError> {
         match xrpl_message {
             XRPLMessage::ProverMessage(_) => {
-                match prover_tx.unwrap() {
+                match prover_tx.ok_or(IngestorError::GenericError(
+                    "Prover transaction is None".to_owned(),
+                ))? {
                     Transaction::Payment(tx) => {
                         let tx_status: String = serde_json::from_str(
                             event_attribute(&task.task.event, "status")
@@ -924,7 +928,9 @@ impl<DB: Database> XrplIngestor<DB> {
             // If we have 'payload', store it in the cache and receive the payload_hash.
             let hash = self
                 .gmp_api
-                .post_payload(&hex::decode(payload_str.clone()).unwrap())
+                .post_payload(&hex::decode(payload_str.clone()).map_err(|e| {
+                    IngestorError::GenericError(format!("Failed to decode payload: {}", e))
+                })?)
                 .await
                 .map_err(|e| {
                     IngestorError::GenericError(format!("Failed to store payload in cache: {}", e))
@@ -1018,11 +1024,18 @@ impl<DB: Database> XrplIngestor<DB> {
                             payload_hash: if payload_hash.is_some() {
                                 Some(
                                     std::convert::TryInto::<[u8; 32]>::try_into(
-                                        hex::decode(payload_hash.unwrap()).map_err(|_| {
+                                        hex::decode(payload_hash.ok_or(
                                             IngestorError::GenericError(
-                                                "Failed to hex-decode payload_hash".into(),
-                                            )
-                                        })?,
+                                                "Payload hash is None".to_owned(),
+                                            ),
+                                        )?)
+                                        .map_err(
+                                            |_| {
+                                                IngestorError::GenericError(
+                                                    "Failed to hex-decode payload_hash".into(),
+                                                )
+                                            },
+                                        )?,
                                     )
                                     .map_err(|_| {
                                         IngestorError::GenericError(
@@ -1089,8 +1102,18 @@ impl<DB: Database> XrplIngestor<DB> {
                 let mut message_with_payload = WithPayload::new(message, None);
 
                 if payload.is_some() {
-                    let payload_bytes = hex::decode(payload.unwrap()).unwrap();
-                    message_with_payload.payload = Some(payload_bytes.try_into().unwrap());
+                    let payload_bytes = hex::decode(
+                        payload.ok_or(IngestorError::GenericError("Payload is None".to_owned()))?,
+                    )
+                    .map_err(|e| {
+                        IngestorError::GenericError(format!("Failed to decode payload: {}", e))
+                    })?;
+                    message_with_payload.payload = Some(payload_bytes.try_into().map_err(|e| {
+                        IngestorError::GenericError(format!(
+                            "Failed to convert payload to HexBinary: {}",
+                            e
+                        ))
+                    })?);
                 }
                 Ok(message_with_payload)
             }
@@ -1313,8 +1336,10 @@ impl<DB: Database> IngestorTrait for XrplIngestor<DB> {
                         let tx =
                             xrpl_tx_from_hash(prover_message.tx_id.clone(), &self.client).await?;
                         prover_tx = Some(tx);
-                        self.confirm_prover_message_request(prover_tx.as_ref().unwrap())
-                            .await?
+                        self.confirm_prover_message_request(prover_tx.as_ref().ok_or(
+                            IngestorError::GenericError("Prover transaction is None".to_owned()),
+                        )?)
+                        .await?
                     }
                     XRPLMessage::AddGasMessage(msg) => {
                         self.confirm_add_gas_message_request(msg).await?
@@ -1430,7 +1455,9 @@ impl<DB: Database> IngestorTrait for XrplIngestor<DB> {
                 info!("ConstructProof({}) transaction hash: {}", cc_id, tx_hash);
             }
             Err(e) => {
-                let re = Regex::new(r"(payment for .*? already succeeded)").unwrap();
+                let re = Regex::new(r"(payment for .*? already succeeded)").map_err(|e| {
+                    IngestorError::GenericError(format!("Failed to create regex: {}", e))
+                })?;
 
                 if re.is_match(&e.to_string()) {
                     info!("Payment for {} already succeeded", cc_id);

--- a/xrpl/src/refund_manager.rs
+++ b/xrpl/src/refund_manager.rs
@@ -58,9 +58,13 @@ impl<X: XRPLClientTrait> XRPLRefundManager<X> {
         let mut tx = PaymentTransaction::new(*account_id, pre_fee_amount, recipient_account);
 
         tx.common.memos = vec![Memo {
-            memo_data: Blob::from_hex(&hex::encode_upper(refund_id)).unwrap(),
+            memo_data: Blob::from_hex(&hex::encode_upper(refund_id)).map_err(|e| {
+                RefundManagerError::GenericError(format!("Failed to encode refund_id: {}", e))
+            })?,
             memo_format: None,
-            memo_type: Blob::from_hex(&hex::encode_upper("refund_id")).unwrap(),
+            memo_type: Blob::from_hex(&hex::encode_upper("refund_id")).map_err(|e| {
+                RefundManagerError::GenericError(format!("Failed to encode refund_id: {}", e))
+            })?,
         }];
 
         self.client

--- a/xrpl/src/subscriber.rs
+++ b/xrpl/src/subscriber.rs
@@ -70,7 +70,9 @@ impl<DB: Database, X: XRPLClientTrait> TransactionPoller for XrplSubscriber<DB, 
             .map(|tx| tx.common().ledger_index.unwrap_or(0))
             .max();
         if max_response_ledger.is_some() {
-            self.latest_ledger = max_response_ledger.unwrap().into();
+            self.latest_ledger = max_response_ledger
+                .ok_or(anyhow!("Max response ledger is None"))?
+                .into();
             if let Err(err) = self.store_latest_ledger().await {
                 warn!("{:?}", err);
             }

--- a/xrpl/src/ticket_creator.rs
+++ b/xrpl/src/ticket_creator.rs
@@ -27,7 +27,7 @@ impl XrplTicketCreator {
             return;
         }
 
-        let request = BroadcastRequest::Generic(ticket_create_msg.unwrap());
+        let request = BroadcastRequest::Generic(ticket_create_msg.unwrap_or_default());
 
         let res = self
             .gmp_api
@@ -51,7 +51,7 @@ impl XrplTicketCreator {
                 error!("Failed to broadcast XRPL Ticket Create request: {:?}", e);
             }
         } else {
-            info!("Ticket create submitted: {}", res.unwrap());
+            info!("Ticket create submitted: {}", res.unwrap_or_default());
             sleep_duration = 60; // that's usually how long it takes for the tickets to be confirmed
         }
 

--- a/xrpl/src/utils.rs
+++ b/xrpl/src/utils.rs
@@ -6,7 +6,11 @@ pub fn message_id_from_retry_task(task: RetryTask) -> Result<Option<String>, any
             let message: xrpl_gateway::msg::ExecuteMsg =
                 serde_json::from_str(&task.task.request_payload)?;
             if let xrpl_gateway::msg::ExecuteMsg::VerifyMessages(messages) = message {
-                let tx_id = messages[0].tx_id().tx_hash_as_hex_no_prefix();
+                let tx_id = messages
+                    .first()
+                    .ok_or_else(|| anyhow::anyhow!("No messages found in VerifyMessages payload"))?
+                    .tx_id()
+                    .tx_hash_as_hex_no_prefix();
                 Ok(Some(tx_id.to_string()))
             } else {
                 Err(anyhow::anyhow!("Unknown payload: {:?}", message))


### PR DESCRIPTION
Change all unwraps (even safe ones) so that we can enable `unwrap_used = "warn"` in our cargo and have it enabled for safety in the future.

Also make further changes based on clippy warnings which you can find in cargo.toml and clippy.toml.