### PR TITLE
fix: clippy version and warnings

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -30,8 +30,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: 1.89.0
           components: clippy
 
       - name: Rust Cache

--- a/relayer_base/src/utils.rs
+++ b/relayer_base/src/utils.rs
@@ -214,9 +214,9 @@ pub fn parse_payment_amount(
             })?,
         ))
     } else {
-        return Err(IngestorError::GenericError(
+        Err(IngestorError::GenericError(
             "Payment amount must be either Drops or Issued".to_owned(),
-        ));
+        ))
     }
 }
 

--- a/xrpl/src/broadcaster.rs
+++ b/xrpl/src/broadcaster.rs
@@ -152,13 +152,13 @@ impl<QM: QueuedTransactionsModel, X: XRPLClientTrait> Broadcaster for XRPLBroadc
                 debug!("Successfully stored queued transaction");
             }
 
-            return Ok(BroadcastResult {
+            Ok(BroadcastResult {
                 transaction: tx.clone(),
                 tx_hash,
                 status: Ok(()),
                 message_id,
                 source_chain,
-            });
+            })
         } else {
             log_and_return_error(&tx, &response, message_id, source_chain)
         }

--- a/xrpl/src/ingestor.rs
+++ b/xrpl/src/ingestor.rs
@@ -1229,7 +1229,7 @@ where
                         "Skipping payment that is not for or from the multisig: {:?}",
                         payment
                     );
-                    return Ok(vec![]);
+                    Ok(vec![])
                 }
             }
             Transaction::TicketCreate(_) => self.handle_prover_tx(*tx).await,


### PR DESCRIPTION
Rust toolchain version is now fixed (since it keeps getting updated frequently and the clippy job fails on previously accepted code). We will need to at some point update to latest version though, and sync it with our local toolchains. 

Also fixed a couple of new clippy warnings that popped up with redundant returns.