### PR TITLE
fix(parser): change get to remove in gas_credit_map

### DIFF
--- a/ton/src/transaction_parser/parser.rs
+++ b/ton/src/transaction_parser/parser.rs
@@ -85,7 +85,7 @@ impl<PV: PriceViewTrait> TraceParserTrait for TraceParser<PV> {
         for cc in call_contract {
             let cc_key = cc.key().await?;
             events.push(cc.event(None).await?);
-            if let Some(parser) = gas_credit_map.get(&cc_key) {
+            if let Some(parser) = gas_credit_map.remove(&cc_key) {
                 let message_id = cc.message_id().await?.ok_or_else(|| {
                     TransactionParsingError::Message("Missing message_id".to_string())
                 })?;


### PR DESCRIPTION
In the case of same cc_key (which is possible), one single gas_credit can be matched with multiple call_contract parsers. By using remove, we assure a one to one match of gas_credit with call_contract (albeit kind of random)